### PR TITLE
fix: resource naming condition regex

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -9,7 +9,7 @@ variable "name" {
   description = "The name of the this resource."
 
   validation {
-    condition     = can(regex("^[a-z0-9-]{5,50}$", var.name))
+    condition     = can(regex("^[A-Za-z0-9._()-]{1,254}[A-Za-z0-9_()-]$", var.name))
     error_message = "The name must be between 5 and 50 characters long and can only contain lowercase letters and numbers."
   }
 }


### PR DESCRIPTION
## Description

According to Azure portal, the restriction is: "The resource name must contain between 1 to 255 characters inclusive. The name only allows alphanumeric characters, periods, underscores, hyphens and parenthesis and cannot end in a period."

This PR fixes this with updated regex.

Fixes #40 
Closes #40 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ X ] Azure Verified Module updates:
  - [ X ] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `locals.version.tf.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `locals.version.tf.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `locals.version.tf.json`.
  - [ ] Update to documentation

# Checklist

- [ X ] I'm sure there are no other open Pull Requests for the same update/change
- [ X ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ X ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
